### PR TITLE
Add mp_calendar module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ical"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9f7215ad0d77e69644570dee000c7678a47ba7441062c1b5f918adde0d73cf"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +54,7 @@ name = "moneypenny"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "ical",
  "regex",
  "serde",
  "toml",
@@ -140,6 +150,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ chrono = "0.4"
 regex = "1"
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
+ical = "0.7"

--- a/src/mp_calendar.rs
+++ b/src/mp_calendar.rs
@@ -1,0 +1,56 @@
+use ical;
+use chrono::prelude::*;
+use crate::mp_core;
+
+enum EventStatus {
+    Tentative,
+    Confirmed,
+    Cancelled
+}
+
+pub struct MpEvent {
+    name: String,
+    start_time: DateTime<Utc>,
+    end_time: DateTime<Utc>,
+    location: String,
+    description: String,
+    status: EventStatus
+}
+
+fn output_mp_calendar_message(str_message: String) {
+    let message = mp_core::Message {
+        body: str_message,
+        output_time: true,
+        sender: String::from("Calendar")
+    };
+    mp_core::core_io::output_message(message);
+}
+
+pub mod cal_io {
+    use ical::parser::ical::component::IcalCalendar;
+    use super::MpEvent;
+
+    pub fn parse_file_to_ical_calendar(path: String) -> Result<IcalCalendar, ical::parser::ParserError> {
+        use std::io::BufReader;
+        use std::fs::File;
+
+        let buf = BufReader::new(File::open(path).unwrap());
+        let mut reader = ical::IcalParser::new(buf);
+        
+        let cal_option = reader.next();
+        match cal_option {
+            Some(cal_result) => {
+                super::output_mp_calendar_message(String::from("ICalParser successfully read from file"));
+                return cal_result;
+            }
+            None => {
+                super::output_mp_calendar_message(String::from("ICalParser could not read from file"));
+                return Err(ical::parser::ParserError::NotComplete);
+            }
+        }
+    }
+
+    pub fn extract_events_from_ical(cal: IcalCalendar) -> Vec<MpEvent> {
+        todo!
+    }
+}

--- a/src/mp_calendar.rs
+++ b/src/mp_calendar.rs
@@ -1,20 +1,35 @@
 use ical;
+use std::str::FromStr;
 use chrono::prelude::*;
 use crate::mp_core;
 
+#[derive(Debug)]
 enum EventStatus {
     Tentative,
     Confirmed,
     Cancelled
 }
 
+impl FromStr for EventStatus {
+    type Err = ();
+    fn from_str(input: &str) -> Result<EventStatus, Self::Err> {
+        match input {
+            "TENTATIVE" => Ok(EventStatus::Tentative),
+            "CONFIRMED" => Ok(EventStatus::Confirmed),
+            "CANCELLED" => Ok(EventStatus::Cancelled),
+            _           => Err(()),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct MpEvent {
-    name: String,
-    start_time: DateTime<Utc>,
-    end_time: DateTime<Utc>,
-    location: String,
-    description: String,
-    status: EventStatus
+    name: Option<String>,
+    start_time: Option<DateTime<Utc>>,
+    end_time: Option<DateTime<Utc>>,
+    location: Option<String>,
+    description: Option<String>,
+    status: Option<EventStatus>
 }
 
 fn output_mp_calendar_message(str_message: String) {
@@ -28,7 +43,9 @@ fn output_mp_calendar_message(str_message: String) {
 
 pub mod cal_io {
     use ical::parser::ical::component::IcalCalendar;
-    use super::MpEvent;
+    use super::DateTime;
+    use super::Utc;
+    use super::{MpEvent, EventStatus, FromStr};
 
     pub fn parse_file_to_ical_calendar(path: String) -> Result<IcalCalendar, ical::parser::ParserError> {
         use std::io::BufReader;
@@ -51,6 +68,46 @@ pub mod cal_io {
     }
 
     pub fn extract_events_from_ical(cal: IcalCalendar) -> Vec<MpEvent> {
-        todo!
+        let events = cal.events;
+        let mut mp_events: Vec<MpEvent> = vec![];
+        for event in events {
+            let mut mp_event = MpEvent {
+                name: None,
+                start_time: None,
+                end_time: None,
+                location: None,
+                description: None,
+                status: None
+            };
+            let event_props = event.properties;
+            for prop in event_props {
+                let name = prop.name;
+                if name == "SUMMARY" {
+                    mp_event.name = prop.value;
+                } else if name == "DTSTART" {
+                    mp_event.start_time = convert_ical_time_to_utc(prop.value, prop.params);
+                } else if name == "DTEND" {
+                    mp_event.end_time = convert_ical_time_to_utc(prop.value, prop.params);
+                } else if name == "LOCATION" {
+                    mp_event.location = prop.value;
+                } else if name == "DESCRIPTION" {
+                    mp_event.description = prop.value;
+                } else if name == "STATUS" {
+                    match prop.value {
+                        Some(str) => {
+                            mp_event.status = Some(EventStatus::from_str(&str).unwrap());
+                        }
+                        // TODO: assuming an event without a status is tentative may not be the best call. Maybe leave at None?
+                        None => mp_event.status = Some(EventStatus::Tentative)
+                    }
+                }
+            }
+            mp_events.push(mp_event);
+        }
+        return mp_events;
+    }
+
+    fn convert_ical_time_to_utc(ical_time: Option<String>, ical_tz: Option<Vec<(String, Vec<String>)>>) -> Option<DateTime<Utc>> {
+        todo!();
     }
 }

--- a/src/mp_calendar.rs
+++ b/src/mp_calendar.rs
@@ -163,6 +163,19 @@ mod calendar_mpevent_tests {
     }
 
     #[test]
+    fn test_cmp_end_time() {
+        let event1 = make_event(100, 300);
+        let event2 = make_event(100, 500);
+        let event3 = make_event(200, 300);
+        let cmp_1_2 = event1.cmp_end_time(&event2);
+        assert_eq!(Ordering::Less, cmp_1_2.unwrap());
+        let cmp_2_1 = event2.cmp_end_time(&event1);
+        assert_eq!(Ordering::Greater, cmp_2_1.unwrap());
+        let cmp_1_3 = event1.cmp_end_time(&event3);
+        assert_eq!(Ordering::Equal, cmp_1_3.unwrap());
+    }
+
+    #[test]
     fn test_ordered_has_overlap() {
         let event1 = make_event(100, 300);
         let event2 = make_event(200, 400);


### PR DESCRIPTION
Reusing core_module_io branch because I forgot to make a new one for the first commit, sue me.

Intentions for this PR:
Parse an ical file into local data structures (aiming for a strict-ish subset of ical functionality)
Add functions to create new events/tasks/whatever programmatically
Re export to new .ics (or custom filetype?)
Add function to determine 'best' slot in free time to accomplish a task with given inputs time, type of task, etc. Try to remember how bin packing works
